### PR TITLE
Copy in license and third party files to docker images.

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -139,6 +139,8 @@ ENV CATTLE_SERVER_VERSION ${VERSION}
 COPY entrypoint.sh rancher /usr/bin/
 COPY kustomize.sh /usr/bin/
 COPY jailer.sh /usr/bin/
+RUN mkdir /license
+COPY LICENSE README.md THIRD_PARTY_LICENSES.txt /license/
 RUN chmod +x /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/kustomize.sh
 

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -26,4 +26,6 @@ ENV DOCKER_API_VERSION 1.24
 ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 COPY agent run.sh kubectl-shell.sh shell-setup.sh share-root.sh /usr/bin/
+RUN mkdir /license
+COPY LICENSE README.md THIRD_PARTY_LICENSES.txt /license/
 ENTRYPOINT ["run.sh"]

--- a/scripts/package
+++ b/scripts/package
@@ -22,6 +22,7 @@ if [ -n "$DRONE_TAG" ]; then
 fi
 
 cp ../bin/rancher ../bin/agent ../bin/data.json .
+cp ../LICENSE ../README.md ../THIRD_PARTY_LICENSES.txt .
 
 IMAGE=${REPO}/rancher:${TAG}
 AGENT_IMAGE=${REPO}/rancher-agent:${TAG}


### PR DESCRIPTION
This PR ensures that the `LICENSE` `README.md` `THIRD_PARTY_LICENSES.txt` files are put into the `/license/` directory on both the rancher and rancher-agent images.

Note, make sure the build process re-tags `v2.4.3` at the `HEAD` of the oracle-build-from-source branch before calling `make`.