### PR TITLE
Change name of docker image for rancher-agent

### DIFF
--- a/BUILD_FROM_SOURCE_README.md
+++ b/BUILD_FROM_SOURCE_README.md
@@ -24,5 +24,4 @@ docker tag rancher/rancher-agent:v2.4.3  ${DOCKER_REPO}/${DOCKER_NAMESPACE}/ranc
 
 docker push ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher:${DOCKER_TAG}
 docker push ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher/rancher-agent:${DOCKER_TAG}
-
 ```

--- a/BUILD_FROM_SOURCE_README.md
+++ b/BUILD_FROM_SOURCE_README.md
@@ -20,9 +20,9 @@ git tag -d v2.4.3
 git tag  v2.4.3 
 make
 docker tag rancher/rancher:v2.4.3  ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher:${DOCKER_TAG}
-docker tag rancher/rancher-agent:v2.4.3  ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher-agent:${DOCKER_TAG}
+docker tag rancher/rancher-agent:v2.4.3  ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher/rancher-agent:${DOCKER_TAG}
 
 docker push ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher:${DOCKER_TAG}
-docker push ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher-agent:${DOCKER_TAG}
+docker push ${DOCKER_REPO}/${DOCKER_NAMESPACE}/rancher/rancher-agent:${DOCKER_TAG}
 
 ```


### PR DESCRIPTION
The rancher code contains a template that expects the image name of agents to be of the form "rancher/rancher-agent:<TAG>". Update the build from source instructions to conform to that naming pattern.

This change is necessary for the verrazzano environment to use the rancher-agent image that we build from source.  Right now the system is failing to find that image.