### PR TITLE
Remove "rancher/" from path to rancher-agent

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -149,7 +149,7 @@ RUN chmod +x /usr/bin/kustomize.sh
 
 COPY data.json /var/lib/rancher-data/driver-metadata/
 
-ENV CATTLE_AGENT_IMAGE ${IMAGE_REPO}/rancher-agent:${VERSION}
+ENV CATTLE_AGENT_IMAGE rancher-agent:${VERSION}
 ENV CATTLE_SERVER_IMAGE ${IMAGE_REPO}/rancher
 ENV ETCD_UNSUPPORTED_ARCH=${ARCH}
 ENV ETCDCTL_API=3

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -26,7 +26,7 @@ RUN curl -sL https://github.com/c-bata/kube-prompt/releases/download/${KUBEPROMP
 ARG VERSION=dev
 LABEL io.cattle.agent true
 ENV DOCKER_API_VERSION 1.24
-ENV AGENT_IMAGE rancher/rancher-agent:${VERSION}
+ENV AGENT_IMAGE rancher-agent:${VERSION}
 ENV SSL_CERT_DIR /etc/kubernetes/ssl/certs
 COPY agent run.sh kubectl-shell.sh shell-setup.sh share-root.sh /usr/bin/
 RUN mkdir /license

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2020, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package image
 
 import (

--- a/pkg/image/resolve.go
+++ b/pkg/image/resolve.go
@@ -32,10 +32,6 @@ func Resolve(image string) string {
 func ResolveWithCluster(image string, cluster *v3.Cluster) string {
 	reg := util.GetPrivateRepoURL(cluster)
 	if reg != "" && !strings.HasPrefix(image, reg) {
-		//Images from Dockerhub Library repo, we add rancher prefix when using private registry
-		if !strings.Contains(image, "/") {
-			image = "rancher/" + image
-		}
 		return path.Join(reg, image)
 	}
 

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -16,7 +16,7 @@ var (
 	provider       Provider
 	InjectDefaults string
 
-	AgentImage                        = NewSetting("agent-image", "rancher/rancher-agent:master-head")
+	AgentImage                        = NewSetting("agent-image", "rancher-agent:master-head")
 	AuthImage                         = NewSetting("auth-image", v3.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)
 	AuthorizationCacheTTLSeconds      = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds  = NewSetting("authorization-deny-cache-ttl-seconds", "10")

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -16,7 +16,7 @@ var (
 	provider       Provider
 	InjectDefaults string
 
-	AgentImage                        = NewSetting("agent-image", "rancher-agent:master-head")
+	AgentImage                        = NewSetting("agent-image", "rancher/rancher-agent:master-head")
 	AuthImage                         = NewSetting("auth-image", v3.ToolsSystemImages.AuthSystemImages.KubeAPIAuth)
 	AuthorizationCacheTTLSeconds      = NewSetting("authorization-cache-ttl-seconds", "10")
 	AuthorizationDenyCacheTTLSeconds  = NewSetting("authorization-deny-cache-ttl-seconds", "10")


### PR DESCRIPTION
Change "rancher/rancher-agent" to just be "rancher-agent".  This is necessary because we are not allowed to add another slash level in the path of the location where the rancher-agent docker image will be published to OCR.

Successful test suite run: https://build.verrazzano.io/job/verrazzano/job/pb-vz887-rancher-agent/1/